### PR TITLE
Add smithery config and healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,7 @@ ENV PYTHONUNBUFFERED=1 \
     MCP_SERVER_PORT=8082 \
     LOG_LEVEL=INFO
 
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:8082/health || exit 1
+
 CMD ["sh", "-c", "cd src && python server.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ uvicorn>=0.20.0
 httpx>=0.25.0
 python-dotenv>=1.0.0
 matplotlib>=3.5.0
+requests>=2.0

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,10 @@
+runtime: "container"
+startCommand:
+  type: "http"
+  configSchema:
+    type: "object"
+    properties: {}
+  exampleConfig: {}
+build:
+  dockerfile: "Dockerfile"
+  dockerBuildPath: "."

--- a/src/server.py
+++ b/src/server.py
@@ -199,7 +199,12 @@ async def read_root():
     """
     return {"message": "ASR-GoT MCP Server is running"}
 
+@app.get("/health")
+async def health_check():
+    """Simple health check endpoint used for Docker healthchecks"""
+    return {"status": "healthy"}
+
 if __name__ == "__main__":
     # Run the server
     port = int(os.getenv("PORT", 8000))
-    uvicorn.run("server:app", host="0.0.0.0", port=port, reload=True)
+    uvicorn.run("server:app", host="0.0.0.0", port=port)


### PR DESCRIPTION
## Summary
- provide minimal smithery.yaml for container deployment
- add health endpoint and disable reload in src/server
- add Docker healthcheck command
- include `requests` in requirements for tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: ConnectionError and FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685b592ff594832aba59525e2d157dc6